### PR TITLE
[chore] JWT認証基盤の実装（ミドルウェア・トークン管理）

### DIFF
--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -1,0 +1,42 @@
+import { SignJWT, jwtVerify } from 'jose'
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-secret-key-change-in-production'
+const JWT_EXPIRES_IN = '7d'
+
+export type JwtPayload = {
+  userId: number
+  role: string
+  email: string
+}
+
+function getSecretKey(): Uint8Array {
+  return new TextEncoder().encode(JWT_SECRET)
+}
+
+/**
+ * JWTトークンを生成する
+ */
+export async function signToken(payload: JwtPayload): Promise<string> {
+  return await new SignJWT({ ...payload })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(JWT_EXPIRES_IN)
+    .sign(getSecretKey())
+}
+
+/**
+ * JWTトークンを検証して、ペイロードを返す
+ * 無効・期限切れの場合は null を返す
+ */
+export async function verifyToken(token: string): Promise<JwtPayload | null> {
+  try {
+    const { payload } = await jwtVerify(token, getSecretKey())
+    return {
+      userId: payload.userId as number,
+      role: payload.role as string,
+      email: payload.email as string,
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/auth/password.ts
+++ b/src/lib/auth/password.ts
@@ -1,0 +1,17 @@
+import bcrypt from 'bcryptjs'
+
+const SALT_ROUNDS = 12
+
+/**
+ * パスワードをハッシュ化する
+ */
+export async function hashPassword(password: string): Promise<string> {
+  return await bcrypt.hash(password, SALT_ROUNDS)
+}
+
+/**
+ * パスワードとハッシュを比較する
+ */
+export async function comparePassword(password: string, hash: string): Promise<boolean> {
+  return await bcrypt.compare(password, hash)
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,73 @@
+import type { NextRequest } from 'next/server'
+import { verifyToken, type JwtPayload } from './jwt'
+
+/**
+ * リクエストのAuthorizationヘッダーからBearerトークンを取り出す
+ */
+function extractBearerToken(request: NextRequest): string | null {
+  const authHeader = request.headers.get('Authorization')
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null
+  }
+  return authHeader.slice(7)
+}
+
+/**
+ * リクエストからログインユーザー情報を取得する
+ * 認証されていない場合は null を返す
+ */
+export async function getSession(request: NextRequest): Promise<JwtPayload | null> {
+  const token = extractBearerToken(request)
+  if (!token) {
+    return null
+  }
+  return await verifyToken(token)
+}
+
+/**
+ * リクエストからログインユーザー情報を取得する
+ * 認証されていない場合は例外を投げる
+ */
+export async function requireSession(request: NextRequest): Promise<JwtPayload> {
+  const session = await getSession(request)
+  if (!session) {
+    throw new UnauthorizedError()
+  }
+  return session
+}
+
+/**
+ * salesロールのユーザーのみ許可する
+ */
+export async function requireSales(request: NextRequest): Promise<JwtPayload> {
+  const session = await requireSession(request)
+  if (session.role !== 'sales') {
+    throw new ForbiddenError()
+  }
+  return session
+}
+
+/**
+ * managerロールのユーザーのみ許可する
+ */
+export async function requireManager(request: NextRequest): Promise<JwtPayload> {
+  const session = await requireSession(request)
+  if (session.role !== 'manager') {
+    throw new ForbiddenError()
+  }
+  return session
+}
+
+export class UnauthorizedError extends Error {
+  constructor() {
+    super('認証が必要です')
+    this.name = 'UnauthorizedError'
+  }
+}
+
+export class ForbiddenError extends Error {
+  constructor() {
+    super('権限が不足しています')
+    this.name = 'ForbiddenError'
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { verifyToken } from './lib/auth/jwt'
+
+// 認証不要なパス
+const PUBLIC_PATHS = ['/api/v1/auth/login', '/api/v1/auth/logout']
+
+export async function middleware(request: NextRequest): Promise<NextResponse> {
+  const { pathname } = request.nextUrl
+
+  // API v1 以外はスキップ
+  if (!pathname.startsWith('/api/v1/')) {
+    return NextResponse.next()
+  }
+
+  // 認証不要なパスはスキップ
+  if (PUBLIC_PATHS.some((path) => pathname.startsWith(path))) {
+    return NextResponse.next()
+  }
+
+  // Authorization ヘッダーを確認
+  const authHeader = request.headers.get('Authorization')
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return NextResponse.json(
+      { error: { code: 'UNAUTHORIZED', message: '認証が必要です' } },
+      { status: 401 }
+    )
+  }
+
+  const token = authHeader.slice(7)
+  const payload = await verifyToken(token)
+
+  if (!payload) {
+    return NextResponse.json(
+      { error: { code: 'UNAUTHORIZED', message: 'トークンが無効または期限切れです' } },
+      { status: 401 }
+    )
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/api/v1/:path*'],
+}


### PR DESCRIPTION
## Summary
- JWT生成・検証ユーティリティ（joseライブラリ使用）
- Next.js Middlewareによる/api/v1/への認証（/auth/loginは除外）
- セッション取得ヘルパー（requireSession/requireSales/requireManager）
- bcryptjsによるパスワードハッシュ化ユーティリティ

## Test plan
- [ ] 有効なトークンでAPIアクセスが通ること（AUTH-007）
- [ ] 無効トークンで401が返ること（AUTH-008）
- [ ] /api/v1/auth/loginは認証なしでアクセス可能なこと

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)