### PR TITLE
[feat] POST /api/v1/auth/logout - ログアウトAPI実装

### DIFF
--- a/src/app/api/v1/auth/logout/route.ts
+++ b/src/app/api/v1/auth/logout/route.ts
@@ -1,0 +1,7 @@
+import { successResponse } from '@/lib/api/response'
+
+// JWT はステートレスなため、サーバーサイドでのトークン無効化は行わない。
+// クライアントはトークンをストレージから削除することでログアウトする。
+export async function POST() {
+  return successResponse(null)
+}


### PR DESCRIPTION
## Summary
- JWTはステートレスなためサーバー側でのトークン無効化は行わない
- クライアント側でトークンを削除する方式でログアウトを実現
- 200 OK + { data: null } を返す

## Test plan
- [ ] POST /api/v1/auth/logoutで200が返ること（AUTH-006）

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)