### PR TITLE
[feat] 日報API実装（Issue #7-#13）

### DIFF
--- a/src/app/api/v1/daily-reports/[id]/approve/route.ts
+++ b/src/app/api/v1/daily-reports/[id]/approve/route.ts
@@ -1,0 +1,65 @@
+import type { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { successResponse, errorResponse } from '@/lib/api/response'
+import { requireSession, UnauthorizedError, ForbiddenError } from '@/lib/auth/session'
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// POST /api/v1/daily-reports/:id/approve - 日報承認
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await requireSession(request)
+    const { id } = await params
+    const reportId = parseInt(id)
+
+    // managerのみ承認可能
+    if (session.role !== 'manager') {
+      return errorResponse('FORBIDDEN', 'マネージャーのみ承認操作が可能です')
+    }
+
+    if (isNaN(reportId)) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+    })
+
+    if (!report) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    // submitted のみ承認可能
+    if (report.status !== 'submitted') {
+      return errorResponse('VALIDATION_ERROR', '提出済み状態の日報のみ承認できます')
+    }
+
+    const now = new Date()
+    const updated = await prisma.dailyReport.update({
+      where: { id: reportId },
+      data: {
+        status: 'approved',
+        approvedBy: session.userId,
+        approvedAt: now,
+      },
+      include: {
+        approver: { select: { id: true, name: true } },
+      },
+    })
+
+    return successResponse({
+      id: updated.id,
+      status: updated.status,
+      approvedBy: updated.approver
+        ? { id: updated.approver.id, name: updated.approver.name }
+        : null,
+      approvedAt: updated.approvedAt?.toISOString() ?? null,
+      updatedAt: updated.updatedAt.toISOString(),
+    })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) return errorResponse('UNAUTHORIZED', error.message)
+    if (error instanceof ForbiddenError) return errorResponse('FORBIDDEN', error.message)
+    console.error('POST /daily-reports/:id/approve error:', error)
+    return errorResponse('INTERNAL_SERVER_ERROR', 'サーバーエラーが発生しました')
+  }
+}

--- a/src/app/api/v1/daily-reports/[id]/reject/route.ts
+++ b/src/app/api/v1/daily-reports/[id]/reject/route.ts
@@ -1,0 +1,53 @@
+import type { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { successResponse, errorResponse } from '@/lib/api/response'
+import { requireSession, UnauthorizedError, ForbiddenError } from '@/lib/auth/session'
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// POST /api/v1/daily-reports/:id/reject - 日報差し戻し
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await requireSession(request)
+    const { id } = await params
+    const reportId = parseInt(id)
+
+    // managerのみ差し戻し可能
+    if (session.role !== 'manager') {
+      return errorResponse('FORBIDDEN', 'マネージャーのみ差し戻し操作が可能です')
+    }
+
+    if (isNaN(reportId)) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+    })
+
+    if (!report) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    // submitted のみ差し戻し可能
+    if (report.status !== 'submitted') {
+      return errorResponse('VALIDATION_ERROR', '提出済み状態の日報のみ差し戻しできます')
+    }
+
+    const updated = await prisma.dailyReport.update({
+      where: { id: reportId },
+      data: { status: 'rejected' },
+    })
+
+    return successResponse({
+      id: updated.id,
+      status: updated.status,
+      updatedAt: updated.updatedAt.toISOString(),
+    })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) return errorResponse('UNAUTHORIZED', error.message)
+    if (error instanceof ForbiddenError) return errorResponse('FORBIDDEN', error.message)
+    console.error('POST /daily-reports/:id/reject error:', error)
+    return errorResponse('INTERNAL_SERVER_ERROR', 'サーバーエラーが発生しました')
+  }
+}

--- a/src/app/api/v1/daily-reports/[id]/route.ts
+++ b/src/app/api/v1/daily-reports/[id]/route.ts
@@ -1,0 +1,101 @@
+import type { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { successResponse, errorResponse } from '@/lib/api/response'
+import { requireSession, UnauthorizedError, ForbiddenError } from '@/lib/auth/session'
+import { dailyReportUpdateSchema } from '@/lib/schemas/daily-report'
+import { formatDailyReport, dailyReportInclude } from '@/lib/api/daily-report-helpers'
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// GET /api/v1/daily-reports/:id - 日報詳細取得
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await requireSession(request)
+    const { id } = await params
+    const reportId = parseInt(id)
+
+    if (isNaN(reportId)) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      include: dailyReportInclude,
+    })
+
+    if (!report) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    // salesは自分の日報のみアクセス可能
+    if (session.role === 'sales' && report.userId !== session.userId) {
+      return errorResponse('FORBIDDEN', 'この日報にアクセスする権限がありません')
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return successResponse(formatDailyReport(report as any))
+  } catch (error) {
+    if (error instanceof UnauthorizedError) return errorResponse('UNAUTHORIZED', error.message)
+    if (error instanceof ForbiddenError) return errorResponse('FORBIDDEN', error.message)
+    console.error('GET /daily-reports/:id error:', error)
+    return errorResponse('INTERNAL_SERVER_ERROR', 'サーバーエラーが発生しました')
+  }
+}
+
+// PUT /api/v1/daily-reports/:id - 日報更新
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await requireSession(request)
+    const { id } = await params
+    const reportId = parseInt(id)
+
+    if (isNaN(reportId)) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+    })
+
+    if (!report) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    // 他ユーザーの日報は更新不可
+    if (report.userId !== session.userId) {
+      return errorResponse('FORBIDDEN', 'この日報を更新する権限がありません')
+    }
+
+    // draft or rejected のみ更新可能
+    if (report.status !== 'draft' && report.status !== 'rejected') {
+      return errorResponse(
+        'VALIDATION_ERROR',
+        'この日報は編集できません（下書きまたは差し戻し状態のみ編集可能）'
+      )
+    }
+
+    const body = await request.json()
+    const parsed = dailyReportUpdateSchema.safeParse(body)
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? 'バリデーションエラー'
+      return errorResponse('VALIDATION_ERROR', message)
+    }
+
+    const updated = await prisma.dailyReport.update({
+      where: { id: reportId },
+      data: {
+        problem: parsed.data.problem ?? undefined,
+        plan: parsed.data.plan ?? undefined,
+      },
+      include: dailyReportInclude,
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return successResponse(formatDailyReport(updated as any))
+  } catch (error) {
+    if (error instanceof UnauthorizedError) return errorResponse('UNAUTHORIZED', error.message)
+    if (error instanceof ForbiddenError) return errorResponse('FORBIDDEN', error.message)
+    console.error('PUT /daily-reports/:id error:', error)
+    return errorResponse('INTERNAL_SERVER_ERROR', 'サーバーエラーが発生しました')
+  }
+}

--- a/src/app/api/v1/daily-reports/[id]/submit/route.ts
+++ b/src/app/api/v1/daily-reports/[id]/submit/route.ts
@@ -1,0 +1,62 @@
+import type { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { successResponse, errorResponse } from '@/lib/api/response'
+import { requireSession, UnauthorizedError, ForbiddenError } from '@/lib/auth/session'
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// POST /api/v1/daily-reports/:id/submit - 日報提出
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await requireSession(request)
+    const { id } = await params
+    const reportId = parseInt(id)
+
+    if (isNaN(reportId)) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      include: { _count: { select: { visitRecords: true } } },
+    })
+
+    if (!report) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません')
+    }
+
+    // 作成者のみ提出可能
+    if (report.userId !== session.userId) {
+      return errorResponse('FORBIDDEN', 'この日報を提出する権限がありません')
+    }
+
+    // draft or rejected のみ提出可能
+    if (report.status !== 'draft' && report.status !== 'rejected') {
+      return errorResponse(
+        'VALIDATION_ERROR',
+        'この日報は提出できません（下書きまたは差し戻し状態のみ提出可能）'
+      )
+    }
+
+    // 訪問記録が1件以上必要
+    if (report._count.visitRecords === 0) {
+      return errorResponse('VALIDATION_ERROR', '訪問記録が1件以上必要です')
+    }
+
+    const updated = await prisma.dailyReport.update({
+      where: { id: reportId },
+      data: { status: 'submitted' },
+    })
+
+    return successResponse({
+      id: updated.id,
+      status: updated.status,
+      updatedAt: updated.updatedAt.toISOString(),
+    })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) return errorResponse('UNAUTHORIZED', error.message)
+    if (error instanceof ForbiddenError) return errorResponse('FORBIDDEN', error.message)
+    console.error('POST /daily-reports/:id/submit error:', error)
+    return errorResponse('INTERNAL_SERVER_ERROR', 'サーバーエラーが発生しました')
+  }
+}

--- a/src/app/api/v1/daily-reports/route.ts
+++ b/src/app/api/v1/daily-reports/route.ts
@@ -1,0 +1,160 @@
+import type { NextRequest } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+import { successResponse, errorResponse } from '@/lib/api/response'
+import { requireSession } from '@/lib/auth/session'
+import { UnauthorizedError, ForbiddenError } from '@/lib/auth/session'
+import { dailyReportCreateSchema, dailyReportListQuerySchema } from '@/lib/schemas/daily-report'
+import { formatDailyReport, dailyReportInclude } from '@/lib/api/daily-report-helpers'
+
+// GET /api/v1/daily-reports - 日報一覧取得
+export async function GET(request: NextRequest) {
+  try {
+    const session = await requireSession(request)
+
+    const { searchParams } = new URL(request.url)
+    const queryParams = {
+      from: searchParams.get('from') ?? undefined,
+      to: searchParams.get('to') ?? undefined,
+      user_id: searchParams.get('user_id') ?? undefined,
+      status: searchParams.get('status') ?? undefined,
+    }
+
+    const parsed = dailyReportListQuerySchema.safeParse(queryParams)
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? 'バリデーションエラー'
+      return errorResponse('VALIDATION_ERROR', message)
+    }
+
+    const { from, to, user_id, status } = parsed.data
+
+    // salesはuser_idフィルターを使用できない
+    if (session.role === 'sales' && user_id !== undefined) {
+      return errorResponse('FORBIDDEN', 'salesユーザーはuser_idフィルターを使用できません')
+    }
+
+    // デフォルト期間: 当月
+    const now = new Date()
+    const defaultFrom = new Date(now.getFullYear(), now.getMonth(), 1)
+    const defaultTo = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+
+    const fromDate = from ? new Date(from) : defaultFrom
+    const toDate = to ? new Date(to) : defaultTo
+    // toDateは日の終わり
+    toDate.setHours(23, 59, 59, 999)
+
+    const reports = await prisma.dailyReport.findMany({
+      where: {
+        // salesは自分の日報のみ
+        userId: session.role === 'sales' ? session.userId : user_id,
+        reportDate: {
+          gte: fromDate,
+          lte: toDate,
+        },
+        ...(status ? { status } : {}),
+      },
+      include: {
+        user: { select: { id: true, name: true } },
+        _count: { select: { visitRecords: true } },
+      },
+      orderBy: { reportDate: 'desc' },
+    })
+
+    const data = reports.map((report) => ({
+      id: report.id,
+      reportDate: report.reportDate.toISOString().split('T')[0],
+      status: report.status,
+      visitCount: report._count.visitRecords,
+      user: { id: report.user.id, name: report.user.name },
+      createdAt: report.createdAt.toISOString(),
+      updatedAt: report.updatedAt.toISOString(),
+    }))
+
+    return successResponse(data)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) return errorResponse('UNAUTHORIZED', error.message)
+    if (error instanceof ForbiddenError) return errorResponse('FORBIDDEN', error.message)
+    console.error('GET /daily-reports error:', error)
+    return errorResponse('INTERNAL_SERVER_ERROR', 'サーバーエラーが発生しました')
+  }
+}
+
+// POST /api/v1/daily-reports - 日報作成
+export async function POST(request: NextRequest) {
+  try {
+    const session = await requireSession(request)
+
+    // salesのみ作成可能
+    if (session.role !== 'sales') {
+      return errorResponse('FORBIDDEN', 'salesロールのユーザーのみ日報を作成できます')
+    }
+
+    const body = await request.json()
+    const parsed = dailyReportCreateSchema.safeParse(body)
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? 'バリデーションエラー'
+      return errorResponse('VALIDATION_ERROR', message)
+    }
+
+    const { report_date, problem, plan, visit_records } = parsed.data
+
+    // 同日の日報が既に存在するか確認
+    const reportDate = new Date(report_date)
+    const existing = await prisma.dailyReport.findFirst({
+      where: {
+        userId: session.userId,
+        reportDate,
+      },
+    })
+
+    if (existing) {
+      return errorResponse('CONFLICT', '同じ報告日の日報が既に存在します')
+    }
+
+    // 顧客IDの存在確認
+    if (visit_records.length > 0) {
+      const customerIds = visit_records.map((vr) => vr.customer_id)
+      const customers = await prisma.customer.findMany({
+        where: { id: { in: customerIds } },
+        select: { id: true },
+      })
+      const foundIds = new Set(customers.map((c) => c.id))
+      const missingId = customerIds.find((id) => !foundIds.has(id))
+      if (missingId) {
+        return errorResponse('VALIDATION_ERROR', `顧客ID ${missingId} が存在しません`)
+      }
+    }
+
+    // 日報を作成
+    const report = await prisma.dailyReport.create({
+      data: {
+        userId: session.userId,
+        reportDate,
+        problem: problem ?? null,
+        plan: plan ?? null,
+        status: 'draft',
+        visitRecords: {
+          create: visit_records.map((vr) => ({
+            customerId: vr.customer_id,
+            visitTime: vr.visit_time,
+            purpose: vr.purpose,
+            caseProduct: vr.case_product ?? null,
+            nextAction: vr.next_action ?? null,
+          })),
+        },
+      },
+      include: dailyReportInclude,
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return successResponse(formatDailyReport(report as any), 201)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) return errorResponse('UNAUTHORIZED', error.message)
+    if (error instanceof ForbiddenError) return errorResponse('FORBIDDEN', error.message)
+    if (error instanceof z.ZodError) {
+      return errorResponse('VALIDATION_ERROR', error.issues[0]?.message ?? 'バリデーションエラー')
+    }
+    console.error('POST /daily-reports error:', error)
+    return errorResponse('INTERNAL_SERVER_ERROR', 'サーバーエラーが発生しました')
+  }
+}

--- a/src/lib/api/daily-report-helpers.ts
+++ b/src/lib/api/daily-report-helpers.ts
@@ -1,0 +1,57 @@
+import type { prisma } from '@/lib/prisma'
+
+// 日報詳細レスポンス用のinclude設定
+export const dailyReportInclude = {
+  user: { select: { id: true, name: true } },
+  approver: { select: { id: true, name: true } },
+  visitRecords: {
+    include: {
+      customer: { select: { id: true, companyName: true } },
+    },
+    orderBy: { visitTime: 'asc' as const },
+  },
+}
+
+// 日報詳細レスポンスの整形
+export function formatDailyReport(
+  report: Awaited<ReturnType<typeof prisma.dailyReport.findUnique>> & {
+    user: { id: number; name: string }
+    approver: { id: number; name: string } | null
+    visitRecords: Array<{
+      id: number
+      customerId: number
+      customer: { id: number; companyName: string }
+      visitTime: string
+      purpose: string
+      caseProduct: string | null
+      nextAction: string | null
+      createdAt: Date
+      updatedAt: Date
+    }>
+  }
+) {
+  if (!report) return null
+  return {
+    id: report.id,
+    reportDate: report.reportDate.toISOString().split('T')[0],
+    problem: report.problem,
+    plan: report.plan,
+    status: report.status,
+    approvedBy: report.approver ? { id: report.approver.id, name: report.approver.name } : null,
+    approvedAt: report.approvedAt?.toISOString() ?? null,
+    user: { id: report.user.id, name: report.user.name },
+    visitRecords: report.visitRecords.map((vr) => ({
+      id: vr.id,
+      customerId: vr.customerId,
+      customerName: vr.customer.companyName,
+      visitTime: vr.visitTime,
+      purpose: vr.purpose,
+      caseProduct: vr.caseProduct,
+      nextAction: vr.nextAction,
+      createdAt: vr.createdAt.toISOString(),
+      updatedAt: vr.updatedAt.toISOString(),
+    })),
+    createdAt: report.createdAt.toISOString(),
+    updatedAt: report.updatedAt.toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary
- GET /api/v1/daily-reports: 日報一覧（salesは自分のみ、期間/ステータス/担当者フィルター）
- POST /api/v1/daily-reports: 日報作成（salesのみ、同日重複チェック）
- GET /api/v1/daily-reports/:id: 日報詳細取得（salesは自分のみ）
- PUT /api/v1/daily-reports/:id: 日報更新（draft/rejected状態のみ）
- POST /api/v1/daily-reports/:id/submit: 日報提出（訪問記録1件以上必須）
- POST /api/v1/daily-reports/:id/approve: 日報承認（managerのみ・submitted状態）
- POST /api/v1/daily-reports/:id/reject: 日報差し戻し（managerのみ・submitted状態）

Closes #7 #8 #9 #10 #11 #12 #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)