### PR TITLE
[feat] 全UI画面実装（SCR-002〜SCR-007） (#22 #23 #24 #25 #26 #27）

### DIFF
--- a/src/app/(dashboard)/approvals/page.tsx
+++ b/src/app/(dashboard)/approvals/page.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+type DailyReport = {
+  id: number
+  reportDate: string
+  visitCount: number
+  user: { id: number; name: string }
+}
+
+export default function ApprovalsPage() {
+  const { user, isLoading, authFetch } = useAuth()
+  const router = useRouter()
+  const [reports, setReports] = useState<DailyReport[]>([])
+  const [isFetching, setIsFetching] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      if (user.role !== 'manager') {
+        router.push('/daily-reports')
+        return
+      }
+      fetchSubmittedReports()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, user])
+
+  async function fetchSubmittedReports() {
+    setIsFetching(true)
+    try {
+      const res = await authFetch('/api/v1/daily-reports?status=submitted')
+      if (res.ok) {
+        const data = await res.json()
+        setReports(data.data)
+      }
+    } finally {
+      setIsFetching(false)
+    }
+  }
+
+  if (isLoading || isFetching) {
+    return <div className="p-8 text-center text-gray-500">読み込み中...</div>
+  }
+
+  return (
+    <div>
+      <h2 className="mb-6 text-2xl font-bold">承認待ち一覧</h2>
+
+      <div className="rounded-md border bg-white">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>報告日</TableHead>
+              <TableHead>担当者</TableHead>
+              <TableHead>訪問件数</TableHead>
+              <TableHead>操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {reports.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="py-8 text-center text-gray-500">
+                  承認待ちの日報がありません
+                </TableCell>
+              </TableRow>
+            ) : (
+              reports.map((report) => (
+                <TableRow key={report.id}>
+                  <TableCell>{new Date(report.reportDate).toLocaleDateString('ja-JP')}</TableCell>
+                  <TableCell>{report.user.name}</TableCell>
+                  <TableCell>{report.visitCount}件</TableCell>
+                  <TableCell>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => router.push(`/daily-reports/${report.id}`)}
+                    >
+                      詳細
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/customers/page.tsx
+++ b/src/app/(dashboard)/customers/page.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+
+type Customer = {
+  id: number
+  company_name: string
+  contact_name: string
+  phone: string | null
+  email: string | null
+  address: string | null
+}
+
+type CustomerForm = {
+  company_name: string
+  contact_name: string
+  phone: string
+  email: string
+  address: string
+}
+
+const emptyForm: CustomerForm = {
+  company_name: '',
+  contact_name: '',
+  phone: '',
+  email: '',
+  address: '',
+}
+
+export default function CustomersPage() {
+  const { user, isLoading, authFetch } = useAuth()
+  const router = useRouter()
+  const [customers, setCustomers] = useState<Customer[]>([])
+  const [search, setSearch] = useState('')
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null)
+  const [form, setForm] = useState<CustomerForm>(emptyForm)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      if (user.role !== 'manager') {
+        router.push('/daily-reports')
+        return
+      }
+      fetchCustomers()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, user])
+
+  async function fetchCustomers() {
+    const params = search ? `?q=${encodeURIComponent(search)}` : ''
+    const res = await authFetch(`/api/v1/customers${params}`)
+    if (res.ok) {
+      const data = await res.json()
+      setCustomers(data.data)
+    }
+  }
+
+  function openCreate() {
+    setEditingCustomer(null)
+    setForm(emptyForm)
+    setFormError(null)
+    setIsDialogOpen(true)
+  }
+
+  function openEdit(customer: Customer) {
+    setEditingCustomer(customer)
+    setForm({
+      company_name: customer.company_name,
+      contact_name: customer.contact_name,
+      phone: customer.phone ?? '',
+      email: customer.email ?? '',
+      address: customer.address ?? '',
+    })
+    setFormError(null)
+    setIsDialogOpen(true)
+  }
+
+  async function handleSave() {
+    setFormError(null)
+    setIsSubmitting(true)
+
+    try {
+      const body = {
+        company_name: form.company_name,
+        contact_name: form.contact_name,
+        phone: form.phone || null,
+        email: form.email || null,
+        address: form.address || null,
+      }
+
+      let res
+      if (editingCustomer) {
+        res = await authFetch(`/api/v1/customers/${editingCustomer.id}`, {
+          method: 'PUT',
+          body: JSON.stringify(body),
+        })
+      } else {
+        res = await authFetch('/api/v1/customers', {
+          method: 'POST',
+          body: JSON.stringify(body),
+        })
+      }
+
+      if (!res.ok) {
+        const data = await res.json()
+        setFormError(data.error?.message ?? '保存に失敗しました')
+        return
+      }
+
+      setIsDialogOpen(false)
+      fetchCustomers()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleDelete(id: number) {
+    if (!confirm('この顧客を削除しますか？')) return
+    await authFetch(`/api/v1/customers/${id}`, { method: 'DELETE' })
+    fetchCustomers()
+  }
+
+  if (isLoading) {
+    return <div className="p-8 text-center text-gray-500">読み込み中...</div>
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-2xl font-bold">顧客マスタ</h2>
+        <Button onClick={openCreate}>+ 新規登録</Button>
+      </div>
+
+      <div className="mb-4 flex gap-2">
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="会社名・担当者名で検索"
+          className="max-w-xs"
+        />
+        <Button variant="outline" onClick={fetchCustomers}>
+          検索
+        </Button>
+      </div>
+
+      <div className="rounded-md border bg-white">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>会社名</TableHead>
+              <TableHead>担当者名</TableHead>
+              <TableHead>電話番号</TableHead>
+              <TableHead>メール</TableHead>
+              <TableHead>操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {customers.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="py-8 text-center text-gray-500">
+                  顧客が登録されていません
+                </TableCell>
+              </TableRow>
+            ) : (
+              customers.map((customer) => (
+                <TableRow key={customer.id}>
+                  <TableCell>{customer.company_name}</TableCell>
+                  <TableCell>{customer.contact_name}</TableCell>
+                  <TableCell>{customer.phone ?? '-'}</TableCell>
+                  <TableCell>{customer.email ?? '-'}</TableCell>
+                  <TableCell>
+                    <div className="flex gap-2">
+                      <Button variant="outline" size="sm" onClick={() => openEdit(customer)}>
+                        編集
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleDelete(customer.id)}
+                      >
+                        削除
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingCustomer ? '顧客編集' : '顧客登録'}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div>
+              <Label>会社名 *</Label>
+              <Input
+                value={form.company_name}
+                onChange={(e) => setForm({ ...form, company_name: e.target.value })}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <Label>担当者名 *</Label>
+              <Input
+                value={form.contact_name}
+                onChange={(e) => setForm({ ...form, contact_name: e.target.value })}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <Label>電話番号</Label>
+              <Input
+                value={form.phone}
+                onChange={(e) => setForm({ ...form, phone: e.target.value })}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <Label>メールアドレス</Label>
+              <Input
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <Label>住所</Label>
+              <Input
+                value={form.address}
+                onChange={(e) => setForm({ ...form, address: e.target.value })}
+                className="mt-1"
+              />
+            </div>
+            {formError && <p className="text-sm text-red-500">{formError}</p>}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
+              キャンセル
+            </Button>
+            <Button onClick={handleSave} disabled={isSubmitting}>
+              保存
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/daily-reports/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/daily-reports/[id]/edit/page.tsx
@@ -1,0 +1,308 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+
+type Customer = {
+  id: number
+  company_name: string
+}
+
+type VisitRecordRow = {
+  id?: number
+  customer_id: string
+  visit_time: string
+  purpose: string
+  case_product: string
+  next_action: string
+}
+
+export default function EditDailyReportPage() {
+  const { user, isLoading, authFetch } = useAuth()
+  const params = useParams()
+  const router = useRouter()
+  const reportId = params.id as string
+
+  const [customers, setCustomers] = useState<Customer[]>([])
+  const [reportDate, setReportDate] = useState('')
+  const [problem, setProblem] = useState('')
+  const [plan, setPlan] = useState('')
+  const [visitRecords, setVisitRecords] = useState<VisitRecordRow[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isFetching, setIsFetching] = useState(true)
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      Promise.all([fetchReport(), fetchCustomers()]).finally(() => setIsFetching(false))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, user])
+
+  async function fetchReport() {
+    const res = await authFetch(`/api/v1/daily-reports/${reportId}`)
+    if (!res.ok) {
+      router.push('/daily-reports')
+      return
+    }
+    const data = await res.json()
+    const report = data.data
+    setReportDate(report.reportDate)
+    setProblem(report.problem ?? '')
+    setPlan(report.plan ?? '')
+    setVisitRecords(
+      report.visitRecords.map(
+        (vr: {
+          id: number
+          customerId: number
+          visitTime: string
+          purpose: string
+          caseProduct: string | null
+          nextAction: string | null
+        }) => ({
+          id: vr.id,
+          customer_id: String(vr.customerId),
+          visit_time: vr.visitTime,
+          purpose: vr.purpose,
+          case_product: vr.caseProduct ?? '',
+          next_action: vr.nextAction ?? '',
+        })
+      )
+    )
+  }
+
+  async function fetchCustomers() {
+    const res = await authFetch('/api/v1/customers')
+    if (res.ok) {
+      const data = await res.json()
+      setCustomers(data.data)
+    }
+  }
+
+  function addVisitRecord() {
+    setVisitRecords([
+      ...visitRecords,
+      { customer_id: '', visit_time: '', purpose: '', case_product: '', next_action: '' },
+    ])
+  }
+
+  function removeVisitRecord(index: number) {
+    setVisitRecords(visitRecords.filter((_, i) => i !== index))
+  }
+
+  function updateVisitRecord(index: number, field: keyof VisitRecordRow, value: string) {
+    const updated = [...visitRecords]
+    updated[index] = { ...updated[index], [field]: value }
+    setVisitRecords(updated)
+  }
+
+  async function handleSave(status: 'draft' | 'submitted') {
+    setError(null)
+    setIsSubmitting(true)
+
+    try {
+      if (status === 'submitted' && visitRecords.length === 0) {
+        setError('提出するには訪問記録が1件以上必要です')
+        return
+      }
+
+      // 日報の problem/plan を更新
+      const updateRes = await authFetch(`/api/v1/daily-reports/${reportId}`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          problem: problem || null,
+          plan: plan || null,
+        }),
+      })
+
+      if (!updateRes.ok) {
+        const data = await updateRes.json()
+        setError(data.error?.message ?? '保存に失敗しました')
+        return
+      }
+
+      // 訪問記録を同期（新規追加のみ対応 - 既存は削除・再追加）
+      // まず既存を全削除
+      for (const vr of visitRecords.filter((vr) => vr.id)) {
+        await authFetch(`/api/v1/visit-records/${vr.id}`, { method: 'DELETE' })
+      }
+
+      // 新規追加
+      for (const vr of visitRecords) {
+        if (!vr.customer_id || !vr.visit_time || !vr.purpose) continue
+        await authFetch(`/api/v1/daily-reports/${reportId}/visit-records`, {
+          method: 'POST',
+          body: JSON.stringify({
+            customer_id: parseInt(vr.customer_id),
+            visit_time: vr.visit_time,
+            purpose: vr.purpose,
+            case_product: vr.case_product || null,
+            next_action: vr.next_action || null,
+          }),
+        })
+      }
+
+      if (status === 'submitted') {
+        const submitRes = await authFetch(`/api/v1/daily-reports/${reportId}/submit`, {
+          method: 'POST',
+        })
+        if (!submitRes.ok) {
+          const data = await submitRes.json()
+          setError(data.error?.message ?? '提出に失敗しました')
+          return
+        }
+      }
+
+      router.push('/daily-reports')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isLoading || isFetching) {
+    return <div className="p-8 text-center text-gray-500">読み込み中...</div>
+  }
+
+  return (
+    <div className="max-w-4xl">
+      <h2 className="mb-6 text-2xl font-bold">日報編集</h2>
+
+      <div className="mb-6">
+        <Label>報告日</Label>
+        <div className="mt-1 text-gray-700">
+          {reportDate ? new Date(reportDate).toLocaleDateString('ja-JP') : ''}
+        </div>
+      </div>
+
+      <div className="mb-6">
+        <div className="mb-2 flex items-center justify-between">
+          <h3 className="font-semibold">訪問記録</h3>
+          <Button type="button" variant="outline" size="sm" onClick={addVisitRecord}>
+            + 追加
+          </Button>
+        </div>
+        {visitRecords.length === 0 ? (
+          <p className="rounded-md border py-4 text-center text-sm text-gray-400">
+            訪問記録がありません
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {visitRecords.map((vr, index) => (
+              <div key={index} className="rounded-md border bg-white p-4">
+                <div className="grid grid-cols-5 gap-3">
+                  <div>
+                    <Label className="text-xs">顧客</Label>
+                    <select
+                      value={vr.customer_id}
+                      onChange={(e) => updateVisitRecord(index, 'customer_id', e.target.value)}
+                      className="mt-1 w-full rounded-md border px-2 py-1.5 text-sm"
+                    >
+                      <option value="">選択...</option>
+                      {customers.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.company_name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <Label className="text-xs">時刻</Label>
+                    <Input
+                      type="time"
+                      value={vr.visit_time}
+                      onChange={(e) => updateVisitRecord(index, 'visit_time', e.target.value)}
+                      className="mt-1"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">訪問目的</Label>
+                    <Input
+                      value={vr.purpose}
+                      onChange={(e) => updateVisitRecord(index, 'purpose', e.target.value)}
+                      placeholder="目的・内容"
+                      className="mt-1"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">案件・商品</Label>
+                    <Input
+                      value={vr.case_product}
+                      onChange={(e) => updateVisitRecord(index, 'case_product', e.target.value)}
+                      placeholder="任意"
+                      className="mt-1"
+                    />
+                  </div>
+                  <div className="flex items-end gap-2">
+                    <div className="flex-1">
+                      <Label className="text-xs">次回アクション</Label>
+                      <Input
+                        value={vr.next_action}
+                        onChange={(e) => updateVisitRecord(index, 'next_action', e.target.value)}
+                        placeholder="任意"
+                        className="mt-1"
+                      />
+                    </div>
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => removeVisitRecord(index)}
+                    >
+                      ✕
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mb-6">
+        <Label htmlFor="problem">Problem（課題・相談）</Label>
+        <Textarea
+          id="problem"
+          value={problem}
+          onChange={(e) => setProblem(e.target.value)}
+          rows={4}
+          className="mt-1"
+        />
+      </div>
+
+      <div className="mb-6">
+        <Label htmlFor="plan">Plan（明日やること）</Label>
+        <Textarea
+          id="plan"
+          value={plan}
+          onChange={(e) => setPlan(e.target.value)}
+          rows={4}
+          className="mt-1"
+        />
+      </div>
+
+      {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+
+      <div className="flex gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => handleSave('draft')}
+          disabled={isSubmitting}
+        >
+          下書き保存
+        </Button>
+        <Button type="button" onClick={() => handleSave('submitted')} disabled={isSubmitting}>
+          提出する
+        </Button>
+        <Button type="button" variant="ghost" onClick={() => router.back()}>
+          キャンセル
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/daily-reports/[id]/page.tsx
+++ b/src/app/(dashboard)/daily-reports/[id]/page.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+type VisitRecord = {
+  id: number
+  customerId: number
+  customerName: string
+  visitTime: string
+  purpose: string
+  caseProduct: string | null
+  nextAction: string | null
+}
+
+type Comment = {
+  id: number
+  targetType: 'problem' | 'plan'
+  content: string
+  user: { id: number; name: string }
+  createdAt: string
+}
+
+type DailyReport = {
+  id: number
+  reportDate: string
+  problem: string | null
+  plan: string | null
+  status: 'draft' | 'submitted' | 'approved' | 'rejected'
+  approvedBy: { id: number; name: string } | null
+  approvedAt: string | null
+  user: { id: number; name: string }
+  visitRecords: VisitRecord[]
+}
+
+const statusLabels: Record<string, string> = {
+  draft: '下書き',
+  submitted: '提出済',
+  approved: '承認済',
+  rejected: '差し戻し',
+}
+
+const statusVariants: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  draft: 'outline',
+  submitted: 'default',
+  approved: 'secondary',
+  rejected: 'destructive',
+}
+
+export default function DailyReportDetailPage() {
+  const { user, isLoading, authFetch } = useAuth()
+  const params = useParams()
+  const router = useRouter()
+  const reportId = params.id as string
+
+  const [report, setReport] = useState<DailyReport | null>(null)
+  const [comments, setComments] = useState<Comment[]>([])
+  const [problemComment, setProblemComment] = useState('')
+  const [planComment, setPlanComment] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  async function fetchReport() {
+    const res = await authFetch(`/api/v1/daily-reports/${reportId}`)
+    if (!res.ok) {
+      router.push('/daily-reports')
+      return
+    }
+    const data = await res.json()
+    setReport(data.data)
+  }
+
+  async function fetchComments() {
+    const res = await authFetch(`/api/v1/daily-reports/${reportId}/comments`)
+    if (res.ok) {
+      const data = await res.json()
+      setComments(data.data)
+    }
+  }
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      fetchReport()
+      fetchComments()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, user, reportId])
+
+  async function handleApprove() {
+    const res = await authFetch(`/api/v1/daily-reports/${reportId}/approve`, { method: 'POST' })
+    if (res.ok) fetchReport()
+    else {
+      const data = await res.json()
+      setError(data.error?.message)
+    }
+  }
+
+  async function handleReject() {
+    const res = await authFetch(`/api/v1/daily-reports/${reportId}/reject`, { method: 'POST' })
+    if (res.ok) fetchReport()
+    else {
+      const data = await res.json()
+      setError(data.error?.message)
+    }
+  }
+
+  async function postComment(targetType: 'problem' | 'plan', content: string) {
+    if (!content.trim()) return
+    const res = await authFetch(`/api/v1/daily-reports/${reportId}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({ target_type: targetType, content }),
+    })
+    if (res.ok) {
+      if (targetType === 'problem') setProblemComment('')
+      else setPlanComment('')
+      fetchComments()
+    }
+  }
+
+  if (isLoading || !report) {
+    return <div className="p-8 text-center text-gray-500">読み込み中...</div>
+  }
+
+  const canEdit =
+    user?.id === report.user.id && (report.status === 'draft' || report.status === 'rejected')
+
+  const canApproveReject = user?.role === 'manager' && report.status === 'submitted'
+
+  const problemComments = comments.filter((c) => c.targetType === 'problem')
+  const planComments = comments.filter((c) => c.targetType === 'plan')
+
+  return (
+    <div className="max-w-4xl">
+      <div className="mb-6 flex items-center gap-4">
+        <h2 className="text-2xl font-bold">
+          日報詳細 - {new Date(report.reportDate).toLocaleDateString('ja-JP')}
+        </h2>
+        <span className="text-gray-600">{report.user.name}</span>
+        <Badge variant={statusVariants[report.status]}>{statusLabels[report.status]}</Badge>
+        {canEdit && (
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/daily-reports/${report.id}/edit`}>編集</Link>
+          </Button>
+        )}
+      </div>
+
+      {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+
+      {/* 訪問記録 */}
+      <section className="mb-8">
+        <h3 className="mb-3 font-semibold text-gray-700">訪問記録</h3>
+        <div className="rounded-md border bg-white">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>顧客</TableHead>
+                <TableHead>時刻</TableHead>
+                <TableHead>訪問目的</TableHead>
+                <TableHead>案件・商品</TableHead>
+                <TableHead>次回アクション</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {report.visitRecords.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-4 text-center text-gray-400">
+                    訪問記録がありません
+                  </TableCell>
+                </TableRow>
+              ) : (
+                report.visitRecords.map((vr) => (
+                  <TableRow key={vr.id}>
+                    <TableCell>{vr.customerName}</TableCell>
+                    <TableCell>{vr.visitTime}</TableCell>
+                    <TableCell>{vr.purpose}</TableCell>
+                    <TableCell>{vr.caseProduct ?? '-'}</TableCell>
+                    <TableCell>{vr.nextAction ?? '-'}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </section>
+
+      {/* Problem */}
+      <section className="mb-8">
+        <h3 className="mb-2 font-semibold text-gray-700">Problem（課題・相談）</h3>
+        <div className="mb-3 min-h-16 rounded-md border bg-white p-4 text-sm whitespace-pre-wrap">
+          {report.problem || <span className="text-gray-400">なし</span>}
+        </div>
+        <div className="mb-3 space-y-2">
+          {problemComments.map((c) => (
+            <div key={c.id} className="rounded-md border bg-gray-50 p-3 text-sm">
+              <div className="mb-1 text-xs text-gray-500">
+                {c.user.name} ({new Date(c.createdAt).toLocaleString('ja-JP')})
+              </div>
+              {c.content}
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <Textarea
+            value={problemComment}
+            onChange={(e) => setProblemComment(e.target.value)}
+            placeholder="コメントを入力..."
+            rows={2}
+            className="flex-1"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="self-end"
+            onClick={() => postComment('problem', problemComment)}
+          >
+            送信
+          </Button>
+        </div>
+      </section>
+
+      {/* Plan */}
+      <section className="mb-8">
+        <h3 className="mb-2 font-semibold text-gray-700">Plan（明日やること）</h3>
+        <div className="mb-3 min-h-16 rounded-md border bg-white p-4 text-sm whitespace-pre-wrap">
+          {report.plan || <span className="text-gray-400">なし</span>}
+        </div>
+        <div className="mb-3 space-y-2">
+          {planComments.map((c) => (
+            <div key={c.id} className="rounded-md border bg-gray-50 p-3 text-sm">
+              <div className="mb-1 text-xs text-gray-500">
+                {c.user.name} ({new Date(c.createdAt).toLocaleString('ja-JP')})
+              </div>
+              {c.content}
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <Textarea
+            value={planComment}
+            onChange={(e) => setPlanComment(e.target.value)}
+            placeholder="コメントを入力..."
+            rows={2}
+            className="flex-1"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="self-end"
+            onClick={() => postComment('plan', planComment)}
+          >
+            送信
+          </Button>
+        </div>
+      </section>
+
+      {/* 承認フロー */}
+      {canApproveReject && (
+        <section className="mb-8 border-t pt-6">
+          <h3 className="mb-3 font-semibold text-gray-700">承認</h3>
+          <div className="flex gap-3">
+            <Button onClick={handleApprove}>承認する</Button>
+            <Button variant="destructive" onClick={handleReject}>
+              差し戻す
+            </Button>
+          </div>
+        </section>
+      )}
+
+      {report.approvedBy && (
+        <p className="text-sm text-gray-500">
+          承認者: {report.approvedBy.name} (
+          {report.approvedAt ? new Date(report.approvedAt).toLocaleString('ja-JP') : ''})
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/app/(dashboard)/daily-reports/new/page.tsx
+++ b/src/app/(dashboard)/daily-reports/new/page.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+
+type Customer = {
+  id: number
+  company_name: string
+}
+
+type VisitRecordRow = {
+  customer_id: string
+  visit_time: string
+  purpose: string
+  case_product: string
+  next_action: string
+}
+
+export default function NewDailyReportPage() {
+  const { user, isLoading, authFetch } = useAuth()
+  const router = useRouter()
+  const [customers, setCustomers] = useState<Customer[]>([])
+  const [reportDate, setReportDate] = useState(new Date().toISOString().split('T')[0])
+  const [problem, setProblem] = useState('')
+  const [plan, setPlan] = useState('')
+  const [visitRecords, setVisitRecords] = useState<VisitRecordRow[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      if (user.role !== 'sales') {
+        router.push('/daily-reports')
+        return
+      }
+      fetchCustomers()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, user])
+
+  async function fetchCustomers() {
+    const res = await authFetch('/api/v1/customers')
+    if (res.ok) {
+      const data = await res.json()
+      setCustomers(data.data)
+    }
+  }
+
+  function addVisitRecord() {
+    setVisitRecords([
+      ...visitRecords,
+      { customer_id: '', visit_time: '', purpose: '', case_product: '', next_action: '' },
+    ])
+  }
+
+  function removeVisitRecord(index: number) {
+    setVisitRecords(visitRecords.filter((_, i) => i !== index))
+  }
+
+  function updateVisitRecord(index: number, field: keyof VisitRecordRow, value: string) {
+    const updated = [...visitRecords]
+    updated[index] = { ...updated[index], [field]: value }
+    setVisitRecords(updated)
+  }
+
+  async function handleSave(status: 'draft' | 'submitted') {
+    setError(null)
+    setIsSubmitting(true)
+
+    try {
+      // バリデーション
+      if (status === 'submitted' && visitRecords.length === 0) {
+        setError('提出するには訪問記録が1件以上必要です')
+        return
+      }
+
+      if (status === 'submitted') {
+        for (const vr of visitRecords) {
+          if (!vr.customer_id || !vr.visit_time || !vr.purpose) {
+            setError('訪問記録の必須項目（顧客・時刻・目的）を入力してください')
+            return
+          }
+        }
+      }
+
+      const body = {
+        report_date: reportDate,
+        problem: problem || null,
+        plan: plan || null,
+        visit_records: visitRecords.map((vr) => ({
+          customer_id: parseInt(vr.customer_id),
+          visit_time: vr.visit_time,
+          purpose: vr.purpose,
+          case_product: vr.case_product || null,
+          next_action: vr.next_action || null,
+        })),
+      }
+
+      const res = await authFetch('/api/v1/daily-reports', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+
+      const data = await res.json()
+
+      if (!res.ok) {
+        setError(data.error?.message ?? '保存に失敗しました')
+        return
+      }
+
+      // 提出する場合は別途submitエンドポイントを呼ぶ
+      if (status === 'submitted') {
+        const submitRes = await authFetch(`/api/v1/daily-reports/${data.data.id}/submit`, {
+          method: 'POST',
+        })
+        if (!submitRes.ok) {
+          const submitData = await submitRes.json()
+          setError(submitData.error?.message ?? '提出に失敗しました')
+          return
+        }
+      }
+
+      router.push('/daily-reports')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isLoading) {
+    return <div className="p-8 text-center text-gray-500">読み込み中...</div>
+  }
+
+  return (
+    <div className="max-w-4xl">
+      <h2 className="mb-6 text-2xl font-bold">日報作成</h2>
+
+      <div className="mb-6">
+        <Label htmlFor="reportDate">報告日</Label>
+        <Input
+          id="reportDate"
+          type="date"
+          value={reportDate}
+          onChange={(e) => setReportDate(e.target.value)}
+          className="mt-1 w-48"
+        />
+      </div>
+
+      <div className="mb-6">
+        <div className="mb-2 flex items-center justify-between">
+          <h3 className="font-semibold">訪問記録</h3>
+          <Button type="button" variant="outline" size="sm" onClick={addVisitRecord}>
+            + 追加
+          </Button>
+        </div>
+        {visitRecords.length === 0 ? (
+          <p className="rounded-md border py-4 text-center text-sm text-gray-400">
+            訪問記録がありません
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {visitRecords.map((vr, index) => (
+              <div key={index} className="rounded-md border bg-white p-4">
+                <div className="grid grid-cols-5 gap-3">
+                  <div>
+                    <Label className="text-xs">顧客</Label>
+                    <select
+                      value={vr.customer_id}
+                      onChange={(e) => updateVisitRecord(index, 'customer_id', e.target.value)}
+                      className="mt-1 w-full rounded-md border px-2 py-1.5 text-sm"
+                    >
+                      <option value="">選択...</option>
+                      {customers.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.company_name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <Label className="text-xs">時刻</Label>
+                    <Input
+                      type="time"
+                      value={vr.visit_time}
+                      onChange={(e) => updateVisitRecord(index, 'visit_time', e.target.value)}
+                      className="mt-1"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">訪問目的</Label>
+                    <Input
+                      value={vr.purpose}
+                      onChange={(e) => updateVisitRecord(index, 'purpose', e.target.value)}
+                      placeholder="目的・内容"
+                      className="mt-1"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">案件・商品</Label>
+                    <Input
+                      value={vr.case_product}
+                      onChange={(e) => updateVisitRecord(index, 'case_product', e.target.value)}
+                      placeholder="任意"
+                      className="mt-1"
+                    />
+                  </div>
+                  <div className="flex items-end gap-2">
+                    <div className="flex-1">
+                      <Label className="text-xs">次回アクション</Label>
+                      <Input
+                        value={vr.next_action}
+                        onChange={(e) => updateVisitRecord(index, 'next_action', e.target.value)}
+                        placeholder="任意"
+                        className="mt-1"
+                      />
+                    </div>
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => removeVisitRecord(index)}
+                    >
+                      ✕
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mb-6">
+        <Label htmlFor="problem">Problem（課題・相談）</Label>
+        <Textarea
+          id="problem"
+          value={problem}
+          onChange={(e) => setProblem(e.target.value)}
+          rows={4}
+          className="mt-1"
+          placeholder="今日の課題や相談事項を入力..."
+        />
+      </div>
+
+      <div className="mb-6">
+        <Label htmlFor="plan">Plan（明日やること）</Label>
+        <Textarea
+          id="plan"
+          value={plan}
+          onChange={(e) => setPlan(e.target.value)}
+          rows={4}
+          className="mt-1"
+          placeholder="明日の予定を入力..."
+        />
+      </div>
+
+      {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+
+      <div className="flex gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => handleSave('draft')}
+          disabled={isSubmitting}
+        >
+          下書き保存
+        </Button>
+        <Button type="button" onClick={() => handleSave('submitted')} disabled={isSubmitting}>
+          提出する
+        </Button>
+        <Button type="button" variant="ghost" onClick={() => router.back()}>
+          キャンセル
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/daily-reports/page.tsx
+++ b/src/app/(dashboard)/daily-reports/page.tsx
@@ -1,7 +1,155 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Input } from '@/components/ui/input'
+
+type DailyReport = {
+  id: number
+  reportDate: string
+  status: 'draft' | 'submitted' | 'approved' | 'rejected'
+  visitCount: number
+  user: { id: number; name: string }
+}
+
+const statusLabels: Record<string, string> = {
+  draft: '下書き',
+  submitted: '提出済',
+  approved: '承認済',
+  rejected: '差し戻し',
+}
+
+const statusVariants: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  draft: 'outline',
+  submitted: 'default',
+  approved: 'secondary',
+  rejected: 'destructive',
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('ja-JP')
+}
+
+function getDefaultDateRange() {
+  const now = new Date()
+  const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split('T')[0]
+  const to = new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().split('T')[0]
+  return { from, to }
+}
+
 export default function DailyReportsPage() {
+  const { user, isLoading, authFetch } = useAuth()
+  const router = useRouter()
+  const [reports, setReports] = useState<DailyReport[]>([])
+  const [isFetching, setIsFetching] = useState(false)
+  const { from: defaultFrom, to: defaultTo } = getDefaultDateRange()
+  const [from, setFrom] = useState(defaultFrom)
+  const [to, setTo] = useState(defaultTo)
+
+  async function fetchReports() {
+    if (!user) return
+    setIsFetching(true)
+    try {
+      const params = new URLSearchParams({ from, to })
+      const res = await authFetch(`/api/v1/daily-reports?${params}`)
+      if (res.ok) {
+        const data = await res.json()
+        setReports(data.data)
+      }
+    } finally {
+      setIsFetching(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      fetchReports()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, user])
+
+  if (isLoading) {
+    return <div className="p-8 text-center text-gray-500">読み込み中...</div>
+  }
+
   return (
-    <main className="p-8">
-      <p className="text-muted-foreground">日報一覧画面（Issue #22 で実装予定）</p>
-    </main>
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-2xl font-bold">日報一覧</h2>
+        {user?.role === 'sales' && (
+          <Button asChild>
+            <Link href="/daily-reports/new">+ 新規作成</Link>
+          </Button>
+        )}
+      </div>
+
+      <div className="mb-4 flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-gray-600">期間:</label>
+          <Input
+            type="date"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            className="w-40"
+          />
+          <span className="text-gray-400">〜</span>
+          <Input type="date" value={to} onChange={(e) => setTo(e.target.value)} className="w-40" />
+          <Button variant="outline" size="sm" onClick={fetchReports} disabled={isFetching}>
+            絞り込み
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-md border bg-white">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>報告日</TableHead>
+              <TableHead>担当者</TableHead>
+              <TableHead>訪問件数</TableHead>
+              <TableHead>ステータス</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {reports.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="py-8 text-center text-gray-500">
+                  日報がありません
+                </TableCell>
+              </TableRow>
+            ) : (
+              reports.map((report) => (
+                <TableRow
+                  key={report.id}
+                  className="cursor-pointer hover:bg-gray-50"
+                  onClick={() => router.push(`/daily-reports/${report.id}`)}
+                >
+                  <TableCell>{formatDate(report.reportDate)}</TableCell>
+                  <TableCell>{report.user.name}</TableCell>
+                  <TableCell>{report.visitCount}件</TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariants[report.status]}>
+                      {statusLabels[report.status]}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
   )
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,12 @@
+import { Header } from '@/components/Header'
+import { Navigation } from '@/components/Navigation'
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <Navigation />
+      <main className="container mx-auto px-6 py-6">{children}</main>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -1,0 +1,246 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+
+type User = {
+  id: number
+  name: string
+  email: string
+  role: 'sales' | 'manager'
+  created_at: string
+}
+
+type UserForm = {
+  name: string
+  email: string
+  password: string
+  role: 'sales' | 'manager'
+}
+
+const emptyForm: UserForm = {
+  name: '',
+  email: '',
+  password: '',
+  role: 'sales',
+}
+
+export default function UsersPage() {
+  const { user: currentUser, isLoading, authFetch } = useAuth()
+  const router = useRouter()
+  const [users, setUsers] = useState<User[]>([])
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [editingUser, setEditingUser] = useState<User | null>(null)
+  const [form, setForm] = useState<UserForm>(emptyForm)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading && currentUser) {
+      if (currentUser.role !== 'manager') {
+        router.push('/daily-reports')
+        return
+      }
+      fetchUsers()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, currentUser])
+
+  async function fetchUsers() {
+    const res = await authFetch('/api/v1/users')
+    if (res.ok) {
+      const data = await res.json()
+      setUsers(data.data)
+    }
+  }
+
+  function openCreate() {
+    setEditingUser(null)
+    setForm(emptyForm)
+    setFormError(null)
+    setIsDialogOpen(true)
+  }
+
+  function openEdit(user: User) {
+    setEditingUser(user)
+    setForm({
+      name: user.name,
+      email: user.email,
+      password: '',
+      role: user.role,
+    })
+    setFormError(null)
+    setIsDialogOpen(true)
+  }
+
+  async function handleSave() {
+    setFormError(null)
+    setIsSubmitting(true)
+
+    try {
+      let res
+      if (editingUser) {
+        const body: {
+          name?: string
+          email?: string
+          role?: string
+          password?: string
+        } = {
+          name: form.name,
+          email: form.email,
+          role: form.role,
+        }
+        if (form.password) body.password = form.password
+
+        res = await authFetch(`/api/v1/users/${editingUser.id}`, {
+          method: 'PUT',
+          body: JSON.stringify(body),
+        })
+      } else {
+        res = await authFetch('/api/v1/users', {
+          method: 'POST',
+          body: JSON.stringify(form),
+        })
+      }
+
+      if (!res.ok) {
+        const data = await res.json()
+        setFormError(data.error?.message ?? '保存に失敗しました')
+        return
+      }
+
+      setIsDialogOpen(false)
+      fetchUsers()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isLoading) {
+    return <div className="p-8 text-center text-gray-500">読み込み中...</div>
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-2xl font-bold">ユーザーマスタ</h2>
+        <Button onClick={openCreate}>+ 新規登録</Button>
+      </div>
+
+      <div className="rounded-md border bg-white">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>氏名</TableHead>
+              <TableHead>メールアドレス</TableHead>
+              <TableHead>ロール</TableHead>
+              <TableHead>操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="py-8 text-center text-gray-500">
+                  ユーザーが登録されていません
+                </TableCell>
+              </TableRow>
+            ) : (
+              users.map((u) => (
+                <TableRow key={u.id}>
+                  <TableCell>{u.name}</TableCell>
+                  <TableCell>{u.email}</TableCell>
+                  <TableCell>
+                    <Badge variant={u.role === 'manager' ? 'default' : 'secondary'}>
+                      {u.role === 'manager' ? 'マネージャー' : '営業'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Button variant="outline" size="sm" onClick={() => openEdit(u)}>
+                      編集
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingUser ? 'ユーザー編集' : 'ユーザー登録'}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div>
+              <Label>氏名 *</Label>
+              <Input
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <Label>メールアドレス *</Label>
+              <Input
+                type="email"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <Label>{editingUser ? 'パスワード（変更する場合のみ入力）' : 'パスワード *'}</Label>
+              <Input
+                type="password"
+                value={form.password}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <Label>ロール *</Label>
+              <select
+                value={form.role}
+                onChange={(e) => setForm({ ...form, role: e.target.value as 'sales' | 'manager' })}
+                className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+              >
+                <option value="sales">営業</option>
+                <option value="manager">マネージャー</option>
+              </select>
+            </div>
+            {formError && <p className="text-sm text-red-500">{formError}</p>}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
+              キャンセル
+            </Button>
+            <Button onClick={handleSave} disabled={isSubmitting}>
+              保存
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+
+export function Header() {
+  const { user, logout } = useAuth()
+
+  return (
+    <header className="flex items-center justify-between border-b bg-white px-6 py-3 shadow-sm">
+      <h1 className="text-lg font-semibold text-gray-800">営業日報システム</h1>
+      {user && (
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-gray-600">{user.name}</span>
+          <Badge variant={user.role === 'manager' ? 'default' : 'secondary'}>
+            {user.role === 'manager' ? 'マネージャー' : '営業'}
+          </Badge>
+          <Button variant="outline" size="sm" onClick={logout}>
+            ログアウト
+          </Button>
+        </div>
+      )}
+    </header>
+  )
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useAuth } from '@/hooks/useAuth'
+import { cn } from '@/lib/utils'
+
+export function Navigation() {
+  const pathname = usePathname()
+  const { user } = useAuth()
+
+  const navItems = [
+    { href: '/daily-reports', label: '日報一覧', roles: ['sales', 'manager'] },
+    { href: '/approvals', label: '承認一覧', roles: ['manager'] },
+    { href: '/customers', label: '顧客マスタ', roles: ['manager'] },
+    { href: '/users', label: 'ユーザーマスタ', roles: ['manager'] },
+  ]
+
+  if (!user) return null
+
+  return (
+    <nav className="border-b bg-gray-50 px-6">
+      <div className="flex gap-6">
+        {navItems
+          .filter((item) => item.roles.includes(user.role))
+          .map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'border-b-2 py-3 text-sm font-medium transition-colors',
+                pathname.startsWith(item.href)
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-gray-600 hover:text-gray-900'
+              )}
+            >
+              {item.label}
+            </Link>
+          ))}
+      </div>
+    </nav>
+  )
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { Slot } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90',
+        outline:
+          'border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        ghost: '[a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 [a&]:hover:underline',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : 'span'
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import * as React from 'react'
+import { XIcon } from 'lucide-react'
+import { Dialog as DialogPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'bg-background data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import * as React from 'react'
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
+import { Select as SelectPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: 'sm' | 'default'
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='text-'])]:text-muted-foreground flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'item-aligned',
+  align = 'center',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          'bg-popover text-popover-foreground data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1'
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
+      {...props}
+    />
+  )
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export type AuthUser = {
+  id: number
+  name: string
+  email: string
+  role: 'sales' | 'manager'
+}
+
+export function useAuth() {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const router = useRouter()
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem('token')
+    const storedUser = localStorage.getItem('user')
+
+    if (!storedToken || !storedUser) {
+      router.push('/login')
+      return
+    }
+
+    try {
+      setToken(storedToken)
+      setUser(JSON.parse(storedUser))
+    } catch {
+      localStorage.removeItem('token')
+      localStorage.removeItem('user')
+      router.push('/login')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [router])
+
+  function logout() {
+    fetch('/api/v1/auth/logout', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    }).finally(() => {
+      localStorage.removeItem('token')
+      localStorage.removeItem('user')
+      router.push('/login')
+    })
+  }
+
+  function authFetch(url: string, options?: RequestInit) {
+    return fetch(url, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        ...options?.headers,
+      },
+    })
+  }
+
+  return { user, token, isLoading, logout, authFetch }
+}


### PR DESCRIPTION
## Summary
- SCR-002: 日報一覧（期間フィルター、ステータスバッジ、salesは自分のみ表示）
- SCR-003: 日報作成（訪問記録追加/削除、下書き保存・提出）
- SCR-003: 日報編集（既存データ復元、訪問記録同期）
- SCR-004: 日報詳細（訪問記録表示、コメント投稿、承認/差し戻し）
- SCR-005: 承認一覧（managerのみ、提出済み日報一覧）
- SCR-006: 顧客マスタ管理（一覧・登録・編集・削除・検索）
- SCR-007: ユーザーマスタ管理（一覧・登録・編集）
- useAuthフック（JWT管理、認証ガード）
- Header/Navigationコンポーネント

Closes #22 #23 #24 #25 #26 #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)