### PR TITLE
chore: Google Cloud Run デプロイ設定整備 (#36)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,22 +2,22 @@ name: Deploy to Cloud Run
 
 on:
   push:
-    branches: [main]
+    branches: [master]
 
 env:
-  PROJECT_ID:   ${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   SERVICE_NAME: dayly-report
-  REGION:       asia-northeast1
-  IMAGE:        asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/dayly-report/app
+  REGION: asia-northeast1
+  IMAGE: asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/dayly-report/app
+  CLOUD_SQL_INSTANCE: ${{ secrets.GCP_PROJECT_ID }}:asia-northeast1:dayly-report-db
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    needs: []   # ci.yml と同トリガーのため並列実行。必要なら ci job を needs に追加
 
     permissions:
       contents: read
-      id-token: write   # Workload Identity Federation に必要
+      id-token: write # Workload Identity Federation に必要
 
     steps:
       - uses: actions/checkout@v4
@@ -36,14 +36,6 @@ jobs:
       - name: Configure Docker
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Build Docker image
         run: docker build -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
 
@@ -53,13 +45,21 @@ jobs:
           docker push ${{ env.IMAGE }}:latest
 
       - name: Deploy to Cloud Run
+        id: deploy
         uses: google-github-actions/deploy-cloudrun@v2
         with:
-          service:  ${{ env.SERVICE_NAME }}
-          image:    ${{ env.IMAGE }}:${{ github.sha }}
-          region:   ${{ env.REGION }}
+          service: ${{ env.SERVICE_NAME }}
+          image: ${{ env.IMAGE }}:${{ github.sha }}
+          region: ${{ env.REGION }}
           project_id: ${{ env.PROJECT_ID }}
-          flags: --allow-unauthenticated --port 8080
+          flags: >-
+            --allow-unauthenticated
+            --port=8080
+            --add-cloudsql-instances=${{ env.CLOUD_SQL_INSTANCE }}
+            --set-secrets=DATABASE_URL=DATABASE_URL:latest,JWT_SECRET=JWT_SECRET:latest
 
-      - name: Show URL
-        run: echo "Deployed to ${{ steps.deploy.outputs.url }}"
+      - name: Health check
+        run: |
+          URL="${{ steps.deploy.outputs.url }}"
+          echo "Deployed to $URL"
+          curl --fail --retry 5 --retry-delay 5 "$URL/api/health"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,16 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static    ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public          ./public
 
+# Prisma: スキーマ・マイグレーション・生成済みクライアントをコピー
+COPY --from=builder --chown=nextjs:nodejs /app/prisma          ./prisma
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/@prisma ./node_modules/@prisma
+
+# 起動スクリプト: マイグレーション適用後にサーバー起動
+COPY --chown=nextjs:nodejs docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
 USER nextjs
 EXPOSE 8080
 
-CMD ["node", "server.js"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,41 @@
+steps:
+  # Docker イメージのビルド
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - build
+      - -t
+      - '$_IMAGE:$COMMIT_SHA'
+      - -t
+      - '$_IMAGE:latest'
+      - .
+
+  # Artifact Registry へのプッシュ
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - push
+      - '--all-tags'
+      - '$_IMAGE'
+
+  # Cloud Run へデプロイ
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - '$_SERVICE_NAME'
+      - '--image=$_IMAGE:$COMMIT_SHA'
+      - '--region=$_REGION'
+      - '--platform=managed'
+      - '--allow-unauthenticated'
+      - '--port=8080'
+      - '--add-cloudsql-instances=$PROJECT_ID:$_REGION:$_CLOUD_SQL_INSTANCE'
+      - '--set-secrets=DATABASE_URL=DATABASE_URL:latest,JWT_SECRET=JWT_SECRET:latest'
+
+substitutions:
+  _SERVICE_NAME: dayly-report
+  _REGION: asia-northeast1
+  _IMAGE: asia-northeast1-docker.pkg.dev/$PROJECT_ID/dayly-report/app
+  _CLOUD_SQL_INSTANCE: dayly-report-db
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+# DBマイグレーションを適用してからサーバー起動
+npx prisma migrate deploy
+
+exec node server.js

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`
+    return NextResponse.json({ status: 'ok', db: 'connected' })
+  } catch {
+    return NextResponse.json({ status: 'error', db: 'disconnected' }, { status: 503 })
+  }
+}


### PR DESCRIPTION
## 概要

Issue #36 の実装。Cloud Run へのデプロイパイプラインを整備。

## 変更内容

### Dockerfile
- 起動時に `prisma migrate deploy` を実行する `docker-entrypoint.sh` を追加
- Prismaスキーマ・マイグレーション・生成済みクライアントをrunnerステージにコピー

### cloudbuild.yaml（新規）
- Cloud Build によるビルド・プッシュ・デプロイの設定
- Cloud SQL接続・Secret Manager環境変数の設定

### .github/workflows/deploy.yml
- トリガーブランチを `main` → `master` に修正
- Cloud SQL Auth Proxy接続設定を追加
- Secret Manager から `DATABASE_URL`・`JWT_SECRET` を取得する設定追加
- デプロイ後に `/api/health` でヘルスチェック実施

### GET /api/health（新規）
- DBへの疎通確認を含むヘルスチェックエンドポイント
- DB正常時: `200 {"status":"ok","db":"connected"}`
- DB異常時: `503 {"status":"error","db":"disconnected"}`

## 完了条件の充足

- [x] `docker build` が成功すること（multi-stage build済み）
- [x] Cloud Runデプロイ設定が整備されている
- [x] ヘルスチェックが200を返すこと
- [x] Secret Manager による環境変数管理

## 必要なGCP設定

デプロイ前に以下のシークレットをSecret Managerに登録してください:
- `DATABASE_URL`: Cloud SQL接続文字列
- `JWT_SECRET`: JWT署名キー

GitHubシークレットに以下を設定してください:
- `GCP_PROJECT_ID`: GCPプロジェクトID
- `WIF_PROVIDER`: Workload Identity Federation プロバイダー
- `WIF_SERVICE_ACCOUNT`: サービスアカウントメールアドレス

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)