### PR TITLE
fix: JWT_SECRET未設定時に本番環境でエラーを発生させてセキュリティリスクを排除 (#62)

### DIFF
--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -1,5 +1,9 @@
 import { SignJWT, jwtVerify } from 'jose'
 
+if (!process.env.JWT_SECRET && process.env.NODE_ENV === 'production') {
+  throw new Error('JWT_SECRET environment variable is required in production')
+}
+
 const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-secret-key-change-in-production'
 const JWT_EXPIRES_IN = '7d'
 


### PR DESCRIPTION
## Summary

- `JWT_SECRET` 環境変数が未設定かつ `NODE_ENV=production` の場合、アプリ起動時に `Error` をthrowするよう修正
- 設定忘れによるデフォルト値使用（JWTトークン偽造リスク）を早期検知できるようにした
- 開発環境（非production）ではこれまで通りデフォルト値にフォールバック

## Test plan

- [ ] 既存テスト84件がすべてパスすること（`npm test`）
- [ ] `NODE_ENV=production` かつ `JWT_SECRET` 未設定の場合、起動時にエラーが発生すること
- [ ] `NODE_ENV=production` かつ `JWT_SECRET` が設定されている場合、正常に動作すること
- [ ] 開発環境（`NODE_ENV` が `production` 以外）では `JWT_SECRET` 未設定でも動作すること

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)